### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/commands/build/build.command.js
+++ b/src/commands/build/build.command.js
@@ -11,6 +11,7 @@ const buildCommands = {
         + '(e.g. "--feature \'users\'" or "-f \'users\'")',
       required: false,
       shortcut: 'f',
+      type: 'string',
     },
     scope: {
       usage:
@@ -18,6 +19,7 @@ const buildCommands = {
         + '(e.g. "--scope \'users\'" or "-s \'users\'")',
       required: false,
       shortcut: 's',
+      type: 'string',
     }
   }
 };

--- a/src/commands/deploy/deploy.command.js
+++ b/src/commands/deploy/deploy.command.js
@@ -8,21 +8,25 @@ const deployCommands = {
       usage:
         'Specify if you want to deploy parallel '
         + '(e.g. "--sm-parallel \'true\'")',
+      type: 'string',
     },
     'sm-scope': {
       usage:
         'Specify if you want to deploy local features or global '
         + '(e.g. "--sm-scope \'local\'")',
+      type: 'string',
     },
     'sm-features': {
       usage:
         'Specify the local features you want to deploy '
         + '(e.g. "--sm-feature \'users\'")',
+      type: 'string',
     },
     'sm-ignore-build': {
       usage:
         'Specify if you want to ignore the build before deploy '
         + '(e.g. "--sm-ignore-build \'true\'")',
+      type: 'string',
     }
   }
 };

--- a/src/commands/feature/feature.command.js
+++ b/src/commands/feature/feature.command.js
@@ -10,6 +10,7 @@ const featureCommands = {
         + '(e.g. "--name \'users\'" or "-m \'users\'")',
       required: true,
       shortcut: 'n',
+      type: 'string',
     },
     remove: {
       usage:
@@ -17,6 +18,7 @@ const featureCommands = {
         + '(e.g. "--remove \'true\'" or "-r \'true\'")',
       required: false,
       shortcut: 'r',
+      type: 'string',
     },
     basePath: {
       usage:
@@ -24,6 +26,7 @@ const featureCommands = {
         + '(e.g. "--basepath \'users\'" or "-b \'users\'")',
       required: false,
       shortcut: 'p',
+      type: 'string',
     }
   }
 };

--- a/src/commands/function/function.command.js
+++ b/src/commands/function/function.command.js
@@ -10,6 +10,7 @@ const functionCommands = {
         + '(e.g. "--name \'login\'" or "-n \'login\'")',
       required: true,
       shortcut: 'n',
+      type: 'string',
     },
     feature: {
       usage:
@@ -17,6 +18,7 @@ const functionCommands = {
         + '(e.g. "--feature \'users\'" or "-f \'users\'")',
       required: true,
       shortcut: 'f',
+      type: 'string',
     },
     path: {
       usage:
@@ -24,6 +26,7 @@ const functionCommands = {
         + '(e.g. "--path \'users\'" or "-p \'users\'")',
       required: false,
       shortcut: 'p',
+      type: 'string',
     },
     method: {
       usage:
@@ -31,6 +34,7 @@ const functionCommands = {
         + '(e.g. "--method \'GET\'" or "-m \'GET\'")',
       required: false,
       shortcut: 'm',
+      type: 'string',
     }
   }
 };


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - ServerlessPlugin for "name", "remove", "basePath", "feature", "path", "method", "scope", "sm-parallel", "sm-scope", "sm-features", "sm-ignore-build"
```